### PR TITLE
clean up some output statements; add optional printing of unused grou…

### DIFF
--- a/CollectUnsuedSecurityGroups.js
+++ b/CollectUnsuedSecurityGroups.js
@@ -93,6 +93,7 @@ function scanForUnusedSecurityGroups(regions, sts) {
 
 let args = process.argv.slice(2, process.argv.length);
 let profile, time, interval;
+let verbose = false;
 let unusedSgs = [];
 
 for (let i = 0; i < args.length; i++) {
@@ -112,6 +113,10 @@ for (let i = 0; i < args.length; i++) {
             interval = args[i + 1];
             i += 1;
             continue;
+        case "-v":
+        case "-verbose":
+            verbose = true;
+            continue;
         case "-h":
         case "help":
         case "-help":
@@ -119,9 +124,10 @@ for (let i = 0; i < args.length; i++) {
                 `To launch it, supply the as set in your AWS credentials file, as such:\n` +
                 `node CollectUnusedSecurityGroups.js\n` +
                 `Parameters: \n-p / -profile\tThe AWS profile to be used, as defined in the AWS credentials file\n` +
-                `-t / -time \\tThe amount of time to run the script (in minuets)\\n` +
-                `-i / -interval\\tThe time interval to sample the unused security groups (in minuets)\\n` +
-                `Example:\n node CollectUnusedSecurityGroup.js -p dev -t 60 -i 5\n`);
+                `-t / -time \tThe amount of time to run the script (in minutes)\n` +
+                `-i / -interval\tThe time interval to sample the unused security groups (in minutes)\n` +
+                `-v / -verbose\tIf set, print the current list of unused SGs after each interval\n` +
+                `Example:\n node CollectUnusedSecurityGroup.js -p dev -t 60 -i 5 -v\n`);
             return;
         default:
             console.error("Bad params\n");
@@ -156,18 +162,27 @@ const collectUnusedSecurityGroups = async (profile) => {
                 console.log("Re-sampling security groups...");
                 let usedSgs = {};
                 let usedSgsPerRegion;
-                unusedSgs.forEach(async (sg) => {
-                    if (!usedSgs[sg.region]) {
-                        usedSgsPerRegion = await getAllSecurityGroupsInUse(sg.region, null);
-                        usedSgs[sg.region] = usedSgsPerRegion;
-                    }
-                    if (usedSgs[sg.region].map(usedSg => usedSg.groupId).includes(sg.groupId)) {
-                        unusedSgs = unusedSgs.filter(x => x.groupId !== sg.groupId);
-                        console.log(`Dropped ${sg.groupId} from unused security groups`);
-                    }
 
+                let requests = unusedSgs.reduce((promiseChain, sg) => {
+                    return promiseChain.then(() => new Promise(async (resolve) => {
+                            if (!usedSgs[sg.region]) {
+                            usedSgsPerRegion = await getAllSecurityGroupsInUse(sg.region, null);
+                            usedSgs[sg.region] = usedSgsPerRegion;
+                        }
+                        if (usedSgs[sg.region].map(usedSg => usedSg.groupId).includes(sg.groupId)) {
+                            unusedSgs = unusedSgs.filter(x => x.groupId !== sg.groupId);
+                            console.log(`Dropped ${sg.groupId} from unused security groups`);
+                        }
+                        resolve();
+                    }));
+                }, Promise.resolve());
 
-                });
+                if (verbose) {
+                    requests.then(() => {
+                        console.log("Current list of unused SGs:")
+                        console.log(unusedSgs);
+                    });
+                }
             }, interval * 60 * 1000);
         });
 };
@@ -181,7 +196,7 @@ if (!interval) {
 setTimeout(() => {
     const unusedSgFilePath = `${process.env.PWD}/unused_security_groups.json`;
     fs.writeFileSync(unusedSgFilePath, JSON.stringify(unusedSgs, null, 2), 'utf-8');
-    console.log(`Unused security groups tracked for ${time} minuets at intervals of ${interval} minuets found at ${unusedSgFilePath} `)
+    console.log(`Unused security groups tracked for ${time} minutes at intervals of ${interval} minutes found at ${unusedSgFilePath} `)
     process.exit(0);
 }, time * 60 * 1000);
 


### PR DESCRIPTION
- Cleaned up some print statements (minuets -> minutes)
- Cleaned up usage text (\\\n, \\\t -> \n, \t)
- Added -v[erbose] option to print the list of unused SGs after each iteration. This makes it easier to see the output before the end of the script, in case you need to stop it or it dies for some reason.

My async JS skills are not tip-top, so t his may not be the best approach, but it works. The solution I have is meant to wait until `unusedSgs.forEach` (formerly on line 159) and all of the "Dropped ..." output completes before printing the unused SGs. 